### PR TITLE
Update dockerfile

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -16,6 +16,11 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 COPY --from=git_installer /usr/bin/git /usr/bin/git
 COPY --from=git_installer /usr/bin/curl /usr/bin/curl
 
+RUN apt-get update && \
+    apt-get install -y gcc  && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 WORKDIR /opt/ScopeSentry/
 
 COPY ./ScopeSentry /opt/ScopeSentry/


### PR DESCRIPTION
在第二个阶段（基于 python:3.7-slim 镜像）中，gcc 编译器找不到。

构建报错：
--------------------
  18 |     COPY ./ScopeSentry /opt/ScopeSentry/
  19 |
  20 | >>> RUN pip install -r requirements.txt  --no-cache-dir
  21 |
  22 |     CMD ["python", "main.py"]


9.342       gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I/usr/local/include/python3.7m -c lib/zoneinfo_module.c -o build/temp.linux-aarch64-cpython-37/lib/zoneinfo_module.o -std=c99
9.342       error: command 'gcc' failed: No such file or directory: 'gcc'
9.342       [end of output]

在第二个阶段安装gcc修复