### PR TITLE
修复旧Project更新出现报错的问题

### DIFF
--- a/api/task/util.py
+++ b/api/task/util.py
@@ -66,6 +66,9 @@ async def get_target_list(raw_target, ignore):
 
 
 async def generate_ignore(ignore):
+    # 处理'NoneType' object has no attribute 'split'的报错
+    if ignore is None:
+        ignore = ""
     ignore_list = []
     regex_list = []
     for t in ignore.split("\n"):


### PR DESCRIPTION
1.4版本创建的项目默认忽略目标为空，
content会返回 ignore:null
导致1.5版本更新会报错：
![image](https://github.com/user-attachments/assets/f2bf3122-83a1-419a-801f-5931422afd24)

`