### PR TITLE
修复：将端口字典引用从“nmap top 1000”更正为“top1000”。

### DIFF
--- a/internal/constants/defaults.go
+++ b/internal/constants/defaults.go
@@ -300,7 +300,7 @@ var ScanTemplateDefault = models.ScanTemplate{
 		SubdomainSecurity:   map[string]string{},
 		PortScanPreparation: map[string]string{},
 		PortScan: map[string]string{
-			"66b4ddeb983387df2b7ee7726653874d": "-port {port.nmap top 1000} -b 600 -t 3000",
+			"66b4ddeb983387df2b7ee7726653874d": "-port {port.top1000} -b 600 -t 3000",
 		},
 		PortFingerprint: map[string]string{},
 		AssetMapping: map[string]string{


### PR DESCRIPTION
修复默认扫描模板中不正确的端口字典引用 - 数据库中的端口字典名称是“top1000”，而不是“nmap top 1000” .
这修复了错误：“未找到端口参数：nmap top 1000” - 与 PortData 中的端口字典定义对齐