### PR TITLE
Fix sensitive rule state validation

### DIFF
--- a/internal/api/handlers/sensitiveRule/sensitive.go
+++ b/internal/api/handlers/sensitiveRule/sensitive.go
@@ -26,14 +26,14 @@ type updateRequest struct {
 	Name    string `json:"name" binding:"required"`
 	Regular string `json:"regular" binding:"required"`
 	Color   string `json:"color" binding:"required"`
-	State   bool   `json:"state" binding:"required"`
+	State   *bool  `json:"state" binding:"required"`
 }
 
 type addRequest struct {
 	Name    string `json:"name" binding:"required"`
 	Regular string `json:"regular" binding:"required"`
 	Color   string `json:"color" binding:"required"`
-	State   bool   `json:"state" binding:"required"`
+	State   *bool  `json:"state" binding:"required"`
 }
 
 type idsStateRequest struct {
@@ -67,7 +67,7 @@ func Update(c *gin.Context) {
 		response.BadRequest(c, "api.bad_request", err)
 		return
 	}
-	if err := sensitiveService.RuleUpdate(c, req.ID, req.Name, req.Regular, req.Color, req.State); err != nil {
+	if err := sensitiveService.RuleUpdate(c, req.ID, req.Name, req.Regular, req.Color, *req.State); err != nil {
 		response.InternalServerError(c, "api.error", err)
 		return
 	}
@@ -81,7 +81,7 @@ func Add(c *gin.Context) {
 		response.BadRequest(c, "api.bad_request", err)
 		return
 	}
-	if err := sensitiveService.RuleAdd(c, req.Name, req.Regular, req.Color, req.State); err != nil {
+	if err := sensitiveService.RuleAdd(c, req.Name, req.Regular, req.Color, *req.State); err != nil {
 		response.InternalServerError(c, "api.error", err)
 		return
 	}

--- a/internal/api/handlers/sensitiveRule/sensitive.go
+++ b/internal/api/handlers/sensitiveRule/sensitive.go
@@ -8,12 +8,17 @@
 package sensitiveRule
 
 import (
+	"sync"
+
 	"github.com/Autumn-27/ScopeSentry/internal/api/response"
 	svc "github.com/Autumn-27/ScopeSentry/internal/services/sensitive_rule"
 	"github.com/gin-gonic/gin"
 )
 
-var sensitiveService svc.Service
+var (
+	sensitiveService     svc.Service
+	sensitiveServiceOnce sync.Once
+)
 
 type listRequest struct {
 	Search    string `json:"search" binding:"omitempty"`
@@ -52,7 +57,7 @@ func Data(c *gin.Context) {
 		response.BadRequest(c, "api.bad_request", err)
 		return
 	}
-	list, total, err := sensitiveService.RuleList(c, req.Search, req.PageIndex, req.PageSize)
+	list, total, err := getSensitiveService().RuleList(c, req.Search, req.PageIndex, req.PageSize)
 	if err != nil {
 		response.InternalServerError(c, "api.error", err)
 		return
@@ -67,7 +72,7 @@ func Update(c *gin.Context) {
 		response.BadRequest(c, "api.bad_request", err)
 		return
 	}
-	if err := sensitiveService.RuleUpdate(c, req.ID, req.Name, req.Regular, req.Color, *req.State); err != nil {
+	if err := getSensitiveService().RuleUpdate(c, req.ID, req.Name, req.Regular, req.Color, *req.State); err != nil {
 		response.InternalServerError(c, "api.error", err)
 		return
 	}
@@ -81,7 +86,7 @@ func Add(c *gin.Context) {
 		response.BadRequest(c, "api.bad_request", err)
 		return
 	}
-	if err := sensitiveService.RuleAdd(c, req.Name, req.Regular, req.Color, *req.State); err != nil {
+	if err := getSensitiveService().RuleAdd(c, req.Name, req.Regular, req.Color, *req.State); err != nil {
 		response.InternalServerError(c, "api.error", err)
 		return
 	}
@@ -95,7 +100,7 @@ func UpdateState(c *gin.Context) {
 		response.BadRequest(c, "api.bad_request", err)
 		return
 	}
-	if _, err := sensitiveService.RuleUpdateState(c, req.IDs, req.State); err != nil {
+	if _, err := getSensitiveService().RuleUpdateState(c, req.IDs, req.State); err != nil {
 		response.InternalServerError(c, "api.error", err)
 		return
 	}
@@ -109,13 +114,16 @@ func Delete(c *gin.Context) {
 		response.BadRequest(c, "api.bad_request", err)
 		return
 	}
-	if _, err := sensitiveService.RuleDelete(c, req.IDs); err != nil {
+	if _, err := getSensitiveService().RuleDelete(c, req.IDs); err != nil {
 		response.InternalServerError(c, "api.error", err)
 		return
 	}
 	response.Success(c, nil, "api.success")
 }
 
-func init() {
-	sensitiveService = svc.NewService()
+func getSensitiveService() svc.Service {
+	sensitiveServiceOnce.Do(func() {
+		sensitiveService = svc.NewService()
+	})
+	return sensitiveService
 }

--- a/internal/api/handlers/sensitiveRule/sensitive_test.go
+++ b/internal/api/handlers/sensitiveRule/sensitive_test.go
@@ -1,0 +1,72 @@
+package sensitiveRule
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestUpdateRequestAcceptsFalseState(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var req updateRequest
+	err := bindSensitiveRuleJSON(
+		`{"id":"6642b0","name":"test-rule","regular":"test","color":"gray","state":false}`,
+		&req,
+	)
+	if err != nil {
+		t.Fatalf("expected update request with false state to bind: %v", err)
+	}
+
+	if req.State == nil {
+		t.Fatal("expected state to be present")
+	}
+	if *req.State {
+		t.Fatal("expected state to be false")
+	}
+}
+
+func TestAddRequestAcceptsFalseState(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var req addRequest
+	err := bindSensitiveRuleJSON(
+		`{"name":"test-rule","regular":"test","color":"gray","state":false}`,
+		&req,
+	)
+	if err != nil {
+		t.Fatalf("expected add request with false state to bind: %v", err)
+	}
+
+	if req.State == nil {
+		t.Fatal("expected state to be present")
+	}
+	if *req.State {
+		t.Fatal("expected state to be false")
+	}
+}
+
+func TestUpdateRequestRequiresState(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var req updateRequest
+	err := bindSensitiveRuleJSON(
+		`{"id":"6642b0","name":"test-rule","regular":"test","color":"gray"}`,
+		&req,
+	)
+	if err == nil {
+		t.Fatal("expected missing state to fail binding")
+	}
+}
+
+func bindSensitiveRuleJSON(body string, req any) error {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	return c.ShouldBindJSON(req)
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- allow sensitive rule add/update requests to explicitly submit `state: false`
- preserve validation that `state` must be present by using pointer booleans
- initialize the sensitive rule service lazily so request-binding tests do not require Mongo/Redis
- add binding tests for disabled sensitive rule state

## Testing
- `go test ./internal/api/handlers/sensitiveRule/ -v`
- `go test ./internal/api/handlers/sensitiveRule/ ./internal/services/sensitive_rule/`

## Notes
- `go build -o /tmp/scopesentry ./cmd/main` currently fails on `cmd/main/main.go` and `cmd/main/basic_usage.go` both declaring `func main`; this appears unrelated to the sensitive rule fix.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b2022136-fb48-4ed1-a34e-764dce2fb151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2022136-fb48-4ed1-a34e-764dce2fb151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

